### PR TITLE
fix(PSWI-934): clean up rebar3 compile warnings

### DIFF
--- a/test/test.erl
+++ b/test/test.erl
@@ -1,5 +1,6 @@
 -module(test).
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -include_lib("xmerl/include/xmerl.hrl").
 


### PR DESCRIPTION
## Summary

PSWI-934: cleanup of `rebar3 compile` warnings. Single-line mechanical fix in `test/test.erl` (`-compile(nowarn_export_all)`).

No semantic changes.

## Verification

- `rebar3 compile`: PASS, 0 warnings
- Used as `_checkouts/` dep under crimson-R5: full umbrella compile clean

## Notes for reviewer

None — purely trivial mechanical add.

## Companion PRs

Part of the PSWI-934 cross-repo warning cleanup. See the umbrella PR in `tutuka/crimson-R5`.

## Test plan

- [ ] Reviewer confirms the trivial change
- [ ] CI compile passes

## Jira

https://paymentology.atlassian.net/browse/PSWI-934
